### PR TITLE
Add command to install dependencies on Arch-based systems (btw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ Debian-based systems:
 ```bash
 apt install pkg-config libglib2.0-dev libcairo2-dev
 ```
+
+Arch-based systems:
+
+```bash
+pacman -S pkgconf glib2 cairo
+```


### PR DESCRIPTION
Title says it all, just adds a command to install the required dependencies on Arch-based systems.